### PR TITLE
Fix example bib entry in spec.html

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -96,7 +96,7 @@ title: "PMLR Proceedings Specification"
     booktitle = {Proceedings of The 2nd International Conference on Examples},
     name = {International Conference on Examples},
     shortname = {ICE},
-    editor = {Jane Smith and Joe Bloggs},
+    editor = {Smith, Jane and Bloggs, Joe},
     volume = {57},
     year = {2013},
     start = {2012-12-15},


### PR DESCRIPTION
This commit fixes a minor typo in spec.html.
**Typo:** The spec advises using a `"Lastname, Firstname"` format for the editors, but the example takes the form: `editor = {Jane Smith and Joe Bloggs}`
**Fix:** The commit changes this to instead use `editor = {Smith, Jane and Bloggs, Joe}`